### PR TITLE
fix: Allow API routes to be accessed by excluding them from rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!api).*)",
       "destination": "/"
     }
   ],


### PR DESCRIPTION
Fixed the contact form error where submissions were failing because the vercel.json rewrite rule was intercepting all requests including /api/* routes and redirecting them to the SPA.

Changes:
- Updated vercel.json rewrite pattern from /(.*) to /((?!api).*)
- This uses negative lookahead to exclude paths starting with 'api'
- API routes at /api/contact and /api/newsletter now work correctly

The contact form should now successfully submit to /api/contact and send emails via SendGrid (if configured) or log submissions as fallback.

Environment variables needed (see .env.example):
- SENDGRID_API_KEY: Required for email sending
- SENDGRID_FROM_EMAIL: Sender email address
- SENDGRID_TO_EMAIL: Admin recipient email address